### PR TITLE
Fix snmptrap plugin

### DIFF
--- a/lib/fluent/plugin/in_snmptrap.rb
+++ b/lib/fluent/plugin/in_snmptrap.rb
@@ -9,6 +9,10 @@ module Fluent
     config_param :port, :integer, :default => 1062
     config_param :community, :string, :default => "public"
 
+    unless method_defined?(:router)
+      define_method(:router) { Engine }
+    end
+
     # Initialize and bring in dependencies
     def initialize
       super
@@ -29,7 +33,7 @@ module Fluent
           tag = @tag 
           timestamp = Engine.now
           record = {"value"=> trap.inspect.to_json,"tags"=>{"type"=>"alert","host"=>trap.source_ip}}
-          Engine.emit(tag, timestamp, record)
+          router.emit(tag, timestamp, record)
         end
       end
     end # def start

--- a/lib/fluent/plugin/in_snmptrap.rb
+++ b/lib/fluent/plugin/in_snmptrap.rb
@@ -5,7 +5,7 @@ module Fluent
 
     # Define default configurations
     config_param :tag, :string, :default => "alert.snmptrap"
-    config_param :host, :integer, :default => 0
+    config_param :host, :string, :default => '0'
     config_param :port, :integer, :default => 1062
     config_param :community, :string, :default => "public"
 

--- a/lib/fluent/plugin/in_snmptrap.rb
+++ b/lib/fluent/plugin/in_snmptrap.rb
@@ -24,7 +24,7 @@ module Fluent
     # Start SNMP Trap listener
     def start
       super
-      m = SNMP::TrapListener.new(:Host => @host,:Port => @port) do |manager|
+      @m = SNMP::TrapListener.new(:Host => @host,:Port => @port) do |manager|
         manager.on_trap_default do |trap|
           tag = @tag 
           timestamp = Engine.now
@@ -32,13 +32,11 @@ module Fluent
           Engine.emit(tag, timestamp, record)
         end
       end
-      trap("INT") { m.exit }
-      m.join
     end # def start
 
     # Stop Listener and cleanup any open connections.
     def shutdown
-      m.exit
+      @m.exit
     end # def shutdown
   end # class SnmpTrapInput
 end # module Fluent

--- a/test/plugin/test_in_snmptrap.rb
+++ b/test/plugin/test_in_snmptrap.rb
@@ -17,8 +17,8 @@ class SnmpTrapInputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver('')
-    assert_equal "0".to_i, d.instance.host
-    assert_equal "1062".to_i, d.instance.port
+    assert_equal "0", d.instance.host
+    assert_equal 1062, d.instance.port
     assert_equal 'alert.snmptrap', d.instance.tag
   end
 end


### PR DESCRIPTION
- Better shutdown code
- Support v0.12 feature
- Add `emit_event_format` parameter to convert SNMPv1 struct to record, not jsonized string.

@Bigel0w Could you check this patch?
