### PR TITLE
support fluentd 0.14

### DIFF
--- a/lib/fluent/plugin/in_snmptrap.rb
+++ b/lib/fluent/plugin/in_snmptrap.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
 # Read snmp trap messages as events in to fluentd
   class SnmpTrapInput < Input
@@ -62,6 +64,7 @@ module Fluent
 
     # Stop Listener and cleanup any open connections.
     def shutdown
+      super
       @m.exit
     end # def shutdown
   end # class SnmpTrapInput


### PR DESCRIPTION
Fix #8 

* add `require 'fluent/input'`
* call `super` in `#shutdown`