### PR TITLE
Refactor plugin for Fluentd v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fluent::Plugin::SnmpTrap
 
-fluent-plugin-snmptrap is an input plug-in for [Fluentd](http://fluentd.org)
+fluent-plugin-snmptrap is an input plug-in for [Fluentd](http://fluentd.org). It works with Fluentd v1.0 and later.
 
 ## Status
 [![Gem Version](https://badge.fury.io/rb/fluent-plugin-snmptrap.png)](http://badge.fury.io/rb/fluent-plugin-snmptrap)

--- a/fluent-plugin-snmptrap.gemspec
+++ b/fluent-plugin-snmptrap.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency "rake", '~> 0.9', '>= 0.9.6'
+  gem.add_development_dependency "rake", '>= 12.0'
+  gem.add_development_dependency "test-unit", ">= 3.0"
 
-  gem.add_runtime_dependency "fluentd", '~> 0.10', '>= 0.10.51'
+  gem.add_runtime_dependency "fluentd", '>= 1.0'
   gem.add_runtime_dependency "snmp", '~> 1.1', '>= 1.1.1'
 end

--- a/lib/fluent/plugin/in_snmptrap.rb
+++ b/lib/fluent/plugin/in_snmptrap.rb
@@ -1,71 +1,62 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
+require 'json'
 
 module Fluent
-# Read snmp trap messages as events in to fluentd
-  class SnmpTrapInput < Input
-    Fluent::Plugin.register_input('snmptrap', self)
+  module Plugin
+    class SnmpTrapInput < Input
+      Fluent::Plugin.register_input('snmptrap', self)
 
-    # Define default configurations
-    config_param :tag, :string, :default => "alert.snmptrap"
-    config_param :host, :string, :default => '0'
-    config_param :port, :integer, :default => 1062
-    config_param :community, :string, :default => "public"
-    config_param :emit_event_format, :string, :default => 'jsonized'
+      helpers :event_emitter
 
-    unless method_defined?(:router)
-      define_method(:router) { Engine }
-    end
+      config_param :tag, :string, default: 'alert.snmptrap'
+      config_param :host, :string, default: '0'
+      config_param :port, :integer, default: 1062
+      config_param :community, :string, default: 'public'
+      config_param :emit_event_format, :string, default: 'jsonized'
 
-    # Initialize and bring in dependencies
-    def initialize
-      super
-      require 'snmp'
-    end # def initialize
+      def initialize
+        super
+        require 'snmp'
+      end
 
-    # Load internal and external configs
-    def configure(conf)
-      super
-      @conf = conf
-      @record_generator = case @emit_event_format
-                          when 'jsonized'
-                            Proc.new { |trap|
-                              {'value' => trap.inspect.to_json}
-                            }
-                          when 'record'
-                            Proc.new { |trap|
-                              {
-                                'source_ip' => trap.source_ip,
-                                'enterprise' => trap.enterprise,
-                                'agent_addr' => trap.agent_addr.to_s,
-                                'specific_trap' => trap.specific_trap,
-                                'generic_trap' => trap.generic_trap.to_s,
-                                'varbind_list' => trap.varbind_list,
-                                'timestamp' => trap.timestamp.to_s
-                              }
-                            }
-                          else
-                            raise ConfigError, "Unknown emit_event_format: '#{@emit_event_format}'"
-                          end
-    end # def configure
+      def configure(conf)
+        super
+        @record_generator = case @emit_event_format
+                            when 'jsonized'
+                              ->(trap) { { 'value' => trap.inspect.to_json } }
+                            when 'record'
+                              lambda do |trap|
+                                {
+                                  'source_ip' => trap.source_ip,
+                                  'enterprise' => trap.enterprise,
+                                  'agent_addr' => trap.agent_addr.to_s,
+                                  'specific_trap' => trap.specific_trap,
+                                  'generic_trap' => trap.generic_trap.to_s,
+                                  'varbind_list' => trap.varbind_list,
+                                  'timestamp' => trap.timestamp.to_s
+                                }
+                              end
+                            else
+                              raise Fluent::ConfigError, "Unknown emit_event_format: '#{@emit_event_format}'"
+                            end
+      end
 
-    # Start SNMP Trap listener
-    def start
-      super
-      @m = SNMP::TrapListener.new(:Host => @host,:Port => @port) do |manager|
-        manager.on_trap_default do |trap|
-          tag = @tag
-          timestamp = Engine.now
-          record = @record_generator.call(trap)
-          record['tags'] = {'type' => 'alert' , 'host' => trap.source_ip}
-          router.emit(tag, timestamp, record)
+      def start
+        super
+        @listener = SNMP::TrapListener.new(host: @host, port: @port) do |manager|
+          manager.on_trap_default do |trap|
+            time = Fluent::EventTime.now
+            record = @record_generator.call(trap)
+            record['tags'] = { 'type' => 'alert', 'host' => trap.source_ip }
+            router.emit(@tag, time, record)
+          end
         end
       end
-    end # def start
 
-    # Stop Listener and cleanup any open connections.
-    def shutdown
-      super
-      @m.exit
-    end # def shutdown
-  end # class SnmpTrapInput
-end # module Fluent
+      def shutdown
+        super
+        @listener.exit if @listener
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/input'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|

--- a/test/plugin/test_in_snmptrap.rb
+++ b/test/plugin/test_in_snmptrap.rb
@@ -12,7 +12,7 @@ class SnmpTrapInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf=CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::SnmpTrapInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::SnmpTrapInput).configure(conf)
   end
 
   def test_configure


### PR DESCRIPTION
## Summary
- modernize gemspec dependencies
- rewrite input plugin using Fluentd v1 API
- update tests for new driver
- note Fluentd v1 compatibility in README

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684214c2f6ac832ab89b6f47b31bc0a5