### PR TITLE
Add MIB loading and SNMPv2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Add the following into your fluentd config.
       host 127.0.0.1      # optional, interface to listen on, default 0 for all.
       port 162            # optional, port to listen for traps, default is 1062
                           # ports under 1024 range will require sudo to start fluentd
-      tag alert.snmptrap  # optional, tag to assign to events, default is alert.snmptrap 
+      tag alert.snmptrap  # optional, tag to assign to events, default is alert.snmptrap
+      mib_dir /path/to/mibs          # optional, directory containing MIB files
+      mib_modules SNMPv2-SMI,SNMPv2-MIB # optional, comma separated modules to load
     </source>
     
     <match alert.snmptrap>
@@ -48,6 +50,4 @@ Send a test trap using net-snmp tools
 ## To Do
 Things left to do, not in any particular order.
 * wrap snmp-trap listener and have it restart on failure.
-* add support for loading MIBs
-* explode the var binds
-* snmp-trap output plug-in that exposes common fields and lets them be overwritten before forwarding.                
+* snmp-trap output plug-in that exposes common fields and lets them be overwritten before forwarding.

--- a/test/plugin/test_in_snmptrap.rb
+++ b/test/plugin/test_in_snmptrap.rb
@@ -9,6 +9,7 @@ class SnmpTrapInputTest < Test::Unit::TestCase
     host 0
     port 1062
     tag alert.snmptrap
+    mib_modules SNMPv2-SMI, SNMPv2-MIB
   ]
 
   def create_driver(conf=CONFIG)
@@ -16,9 +17,10 @@ class SnmpTrapInputTest < Test::Unit::TestCase
   end
 
   def test_configure
-    d = create_driver('')
+    d = create_driver()
     assert_equal "0", d.instance.host
     assert_equal 1062, d.instance.port
     assert_equal 'alert.snmptrap', d.instance.tag
+    assert_equal ['SNMPv2-SMI', 'SNMPv2-MIB'], d.instance.mib_modules
   end
 end


### PR DESCRIPTION
## Summary
- add `mib_dir` and `mib_modules` configuration parameters
- generate record contents for SNMPv1 and SNMPv2 traps separately
- explode varbind list into a hash
- load MIB modules when starting listener
- document new configuration options and remove completed TODO items
- test that `mib_modules` are parsed correctly

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68421716c3d8832a827e08419ecdd195