### PR TITLE
Add restart logic for SNMP trap listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,4 @@ Send a test trap using net-snmp tools
   
 ## To Do
 Things left to do, not in any particular order.
-* wrap snmp-trap listener and have it restart on failure.
 * snmp-trap output plug-in that exposes common fields and lets them be overwritten before forwarding.


### PR DESCRIPTION
## Summary
- allow configuring restart interval with `restart_wait`
- restart snmptrap listener when it unexpectedly exits
- add tests for restart behaviour and adapt existing tests
- remove finished TODO from README

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684220bc5d54832aa56ab0eb227ea3a6